### PR TITLE
Fix deprecated SPDX license identifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
   {name = "Adam Santorelli", email = "adam.santorelli@childmind.org"},
   {name = "Reinder Vos de Wael", email = "reinder.vosdewael@childmind.org"}
 ]
-license = "LGPL-2.1"
+license = "LGPL-2.1-only"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
Updates deprecated SPDX license identifiers to fix build failures.

- `LGPL-2.1` → `LGPL-2.1-only`