### PR TITLE
Hotfix/calculate night number

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "noctsleepy"
-version = "0.1.3"
+version = "0.1.4"
 description = "This package provides a toolbox of functions to compute key metrics about nocturnal sleep from already processed wrist-worn actigraphy data."
 authors = [
   {name = "Adam Santorelli", email = "adam.santorelli@childmind.org"},

--- a/src/noctsleepy/main.py
+++ b/src/noctsleepy/main.py
@@ -114,10 +114,14 @@ def compute_sleep_metrics(
     summary_stats = sleep_variables.extract_simple_statistics(sleep_data)
     nights_metadata = sleep_data.night_data.unique(
         subset=["night_date"], maintain_order=True
-    ).select(["night_date"])
+    ).select(["night_date", "data_start_date"])
 
     nights_metadata = nights_metadata.with_columns(
-        [pl.col("night_date").rank("dense").alias("night_number")]
+        [
+            (
+                (pl.col("night_date") - pl.col("data_start_date")).dt.total_days() + 1
+            ).alias("night_number")
+        ]
     )
 
     output_file.write_text(

--- a/src/noctsleepy/main.py
+++ b/src/noctsleepy/main.py
@@ -114,13 +114,19 @@ def compute_sleep_metrics(
     summary_stats = sleep_variables.extract_simple_statistics(sleep_data)
     nights_metadata = sleep_data.night_data.unique(
         subset=["night_date"], maintain_order=True
-    ).select(["night_date", "day_number"])
+    ).select(["night_date"])
+
+    nights_metadata = nights_metadata.with_columns(
+        [pl.col("night_date").rank("dense").alias("night_number")]
+    )
 
     output_file.write_text(
         json.dumps(
             {
                 "night_dates": nights_metadata["night_date"].cast(pl.Utf8).to_list(),
-                "night_numbers": nights_metadata["day_number"].cast(pl.Utf8).to_list(),
+                "night_numbers": nights_metadata["night_number"]
+                .cast(pl.Utf8)
+                .to_list(),
                 "sleep_metrics": sleep_metrics_dict,
                 "summary_statistics": summary_stats,
             },

--- a/src/noctsleepy/processing/sleep_variables.py
+++ b/src/noctsleepy/processing/sleep_variables.py
@@ -368,8 +368,6 @@ def _filter_nights(
     """Find valid nights in the processed actigraphy data.
 
     A night is defined by the nocturnal interval (default is [20:00 - 08:00) ).
-    A day_number is first added to keep track of the number of days in the study,
-    this is used to provide the "night_number" to the user as part of the output.
     Timestamps are first converted to UTC based on the provided timezone.
     The UTC conversion also keeps track of the offset from the initial local timezone.
     This offset is used to shift the nocturnal window hours.
@@ -396,9 +394,6 @@ def _filter_nights(
         A Polars DataFrame containing only the valid nights.
 
     """
-    data = data.with_columns(
-        [(pl.col("time").dt.date().rank("dense")).alias("day_number")]
-    )
     min_date = data["time"].dt.date().min()
     utc_night_data = _convert_to_utc(data, timezone)
 

--- a/src/noctsleepy/processing/sleep_variables.py
+++ b/src/noctsleepy/processing/sleep_variables.py
@@ -445,7 +445,11 @@ def _filter_nights(
         pl.col("non_wear_percentage") <= nw_threshold
     ).select(["night_date"])
 
-    return nocturnal_sleep.join(valid_nights, on="night_date").sort("local_time")
+    filtered_nights = nocturnal_sleep.join(valid_nights, on="night_date").sort(
+        "local_time"
+    )
+
+    return filtered_nights.with_columns([pl.lit(min_date).alias("data_start_date")])
 
 
 def _convert_to_utc(data: pl.DataFrame, timezone: str) -> pl.DataFrame:

--- a/tests/unit/test_sleep_variables.py
+++ b/tests/unit/test_sleep_variables.py
@@ -52,9 +52,6 @@ def test_filter_nights_cross_midnight(create_dummy_data: pl.DataFrame) -> None:
     assert valid_nights["night_date"].unique().len() == 1, (
         f"Expected 1 valid night, got {valid_nights['night_date'].unique().len()}"
     )
-    assert valid_nights["day_number"].unique().len() == 2, (
-        f"Expected 2 unique days, got {valid_nights['day_number'].unique().len()}"
-    )
     assert time_check, "Not all timestamps are within the nocturnal interval"
 
 
@@ -80,9 +77,6 @@ def test_filter_nights_before_midnight(create_dummy_data: pl.DataFrame) -> None:
 
     assert valid_nights["night_date"].unique().len() == 1, (
         f"Expected 1 valid night, got {valid_nights['night_date'].unique().len()}"
-    )
-    assert valid_nights["day_number"].unique().len() == 1, (
-        f"Expected 1 unique day number, got {valid_nights['day_number'].unique().len()}"
     )
     assert time_check, "Not all timestamps are within the nocturnal interval"
 
@@ -122,14 +116,18 @@ def test_filter_nights_sleep_from_before_data_collection() -> None:
     )
     nights_metadata = valid_nights.unique(
         subset=["night_date"], maintain_order=True
-    ).select(["night_date", "day_number"])
+    ).select(["night_date"])
+
+    nights_metadata = nights_metadata.with_columns(
+        [pl.col("night_date").rank("dense").alias("night_number")]
+    )
 
     assert nights_metadata["night_date"].to_list() == expected_night_dates, (
         f"Expected {expected_night_dates} got {nights_metadata['night_date'].to_list()}"
     )
-    assert nights_metadata["day_number"].to_list() == expected_night_numbers, (
+    assert nights_metadata["night_number"].to_list() == expected_night_numbers, (
         f"Expected {expected_night_numbers} "
-        f"got {nights_metadata['day_number'].to_list()}"
+        f"got {nights_metadata['night_number'].to_list()}"
     )
 
 


### PR DESCRIPTION
Found an inconsistency in calculating the "night_number". Since this was computed based on the day_number/night_date before the `longest_sleep` filtering. In certain cases when sleep starts after midnight + only longest_sleep is kept, there were duplicate night_numbers (even though night_date was correct).

This didn't happen without the longest_sleep filtering. Modified the way night_number is calculated. We simply take the start_date, return a column of that value and then before the final json output we take the number of days since the start (index starting at 1 to match with GGIR)